### PR TITLE
Disable interpretation of backslash escapes

### DIFF
--- a/configure-exports.bash
+++ b/configure-exports.bash
@@ -9,7 +9,7 @@ do
  opt=NFS_EXPORT_OPTIONS_$index
 
  if [[ -n ${!dir} ]] && [[ -n ${!net} ]] && [[ -n ${!opt} ]] ; then
-  echo -e ${!dir} ${!net}'('${!opt}')'
+  echo ${!dir} ${!net}'('${!opt}')'
  fi
 
 done>/etc/exports 


### PR DESCRIPTION
Disable interpretation of backslash escapes in echo print into `/etc/exports`. This causes characters like `\040` to be treated and not written directly, thus causing `exportfs` to not recognize the paths.